### PR TITLE
Remove ULW_COLORKEY (Windows Creator's Update)

### DIFF
--- a/aero-overlay/src/Overlay.cpp
+++ b/aero-overlay/src/Overlay.cpp
@@ -82,7 +82,7 @@ bool Overlay::create(
         m_WndOverlay,
         RGB( NULL, NULL, NULL ),
         255,
-        ULW_COLORKEY | LWA_ALPHA ) ) {
+        LWA_ALPHA ) ) {
         return false;
     }
 


### PR DESCRIPTION
ULW_COLORKEY breaks alpha blending for machines running Windows Version 1703 and higher, removing this flag seems to resolve the issue.